### PR TITLE
Add PNG thumbnail support to scripts

### DIFF
--- a/verify_id_list.py
+++ b/verify_id_list.py
@@ -6,7 +6,7 @@ import sys
 from internetarchive import get_session
 
 video_file_types = {'Matroska', 'WebM', 'MPEG4'}
-thumb_file_types = {'JPEG', 'WebP', 'Thumbnail'}
+thumb_file_types = {'JPEG', 'WebP', 'PNG', 'Thumbnail'}
 info_file_types = {'JSON'}
 
 if ID_FILE == '':

--- a/verify_uploads.py
+++ b/verify_uploads.py
@@ -6,7 +6,7 @@ import sys
 from internetarchive import get_session
 
 video_file_types = {'Matroska', 'WebM', 'MPEG4'}
-thumb_file_types = {'JPEG', 'WebP', 'Thumbnail'}
+thumb_file_types = {'JPEG', 'WebP', 'PNG', 'Thumbnail'}
 info_file_types = {'JSON'}
 
 


### PR DESCRIPTION
I had a bunch of RoosterTeeth videos falsely flag as missing thumbnails until I added a check for PNG thumbnail types. This MIGHT break detection for videos with autogenerated thumbnails (the ones that are all in a subfolder) but not a thumbnail in the main folder, I'm not sure.